### PR TITLE
Potential fix for code scanning alert no. 7: Depending upon JCenter/Bintray as an artifact repository

### DIFF
--- a/api/.mvn/settings.xml
+++ b/api/.mvn/settings.xml
@@ -224,19 +224,6 @@
                     </snapshots>
                 </repository>
 
-                <!-- JCenter (archived but still accessible) -->
-                <repository>
-                    <id>jcenter</id>
-                    <name>JCenter</name>
-                    <url>https://jcenter.bintray.com</url>
-                    <releases>
-                        <enabled>true</enabled>
-                        <updatePolicy>daily</updatePolicy>
-                    </releases>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </repository>
 
                 <!-- Atlassian Public Repository (for some utility libs) -->
                 <repository>


### PR DESCRIPTION
Potential fix for [https://github.com/sharma-manish-94/schemasculpt/security/code-scanning/7](https://github.com/sharma-manish-94/schemasculpt/security/code-scanning/7)

In general, the fix is to stop using JCenter/Bintray as an artifact repository and instead rely on canonical, maintained repositories (typically Maven Central via `https://repo.maven.apache.org/maven2`, or another trusted corporate/organization repository). This means removing the JCenter `<repository>` entry or replacing its URL and identifiers with a supported repository, without changing what artifacts the build resolves where possible.

The best way to fix this specific instance without changing existing functionality is:

- Remove the JCenter `<repository>` block entirely if it is not strictly needed (preferred).
- If the build currently depends on artifacts only available from JCenter, replace the JCenter repository with an appropriate canonical mirror or Maven Central and adjust coordinates elsewhere as needed. Since we must not assume changes outside this file, the safest code‑only change here is to disable/remove the JCenter repository so that Maven no longer attempts to use `https://jcenter.bintray.com`.

Given the code provided, we will remove lines 227–239 (the JCenter comment and `<repository>` block) from `api/.mvn/settings.xml`. No additional methods, imports, or definitions are required; this is purely a configuration clean‑up inside the existing `<profiles>...<repositories>` structure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
