### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/ai_service/test_providers.py
+++ b/ai_service/test_providers.py
@@ -28,7 +28,12 @@ async def test_provider(provider_type: str):
         config = settings.get_provider_config()
         settings.llm_provider = original_provider
 
-        print(f"Configuration: {config}\n")
+        # Avoid logging sensitive values such as API keys
+        safe_config = {
+            key: ("<redacted>" if key == "api_key" and value is not None else value)
+            for key, value in config.items()
+        }
+        print(f"Configuration: {safe_config}\n")
 
         # Create provider
         print(f"Initializing {provider_type} provider...")

--- a/ai_service/test_providers.py
+++ b/ai_service/test_providers.py
@@ -15,6 +15,28 @@ from app.core.config import settings
 from app.providers.provider_factory import ProviderFactory
 
 
+def _redact_sensitive_config(config: dict) -> dict:
+    """Return a copy of the config with sensitive values redacted."""
+    sensitive_keywords = ("key", "secret", "token", "password")
+
+    def _redact(obj):
+        if isinstance(obj, dict):
+            redacted = {}
+            for k, v in obj.items():
+                if isinstance(k, str) and any(
+                    kw in k.lower() for kw in sensitive_keywords
+                ):
+                    redacted[k] = "<redacted>" if v is not None else None
+                else:
+                    redacted[k] = _redact(v)
+            return redacted
+        elif isinstance(obj, list):
+            return [_redact(item) for item in obj]
+        return obj
+
+    return _redact(config)
+
+
 async def test_provider(provider_type: str):
     """Test a specific provider."""
     print(f"\n{'='*60}")
@@ -28,11 +50,8 @@ async def test_provider(provider_type: str):
         config = settings.get_provider_config()
         settings.llm_provider = original_provider
 
-        # Avoid logging sensitive values such as API keys
-        safe_config = {
-            key: ("<redacted>" if key == "api_key" and value is not None else value)
-            for key, value in config.items()
-        }
+        # Avoid logging sensitive values such as API keys or tokens
+        safe_config = _redact_sensitive_config(config)
         print(f"Configuration: {safe_config}\n")
 
         # Create provider


### PR DESCRIPTION
Potential fix for [https://github.com/sharma-manish-94/schemasculpt/security/code-scanning/1](https://github.com/sharma-manish-94/schemasculpt/security/code-scanning/1)

In general, the problem is that the code logs the entire provider configuration dictionary, which may include sensitive fields such as API keys. To fix this, we should avoid printing secrets directly. The usual pattern is to either (1) omit sensitive fields from any logged output, or (2) print only non-sensitive metadata (like provider type, model, URL, and whether a secret is configured) and/or a redacted version of sensitive values.

The minimal, behavior-preserving fix here is to stop logging the raw `config` dict and instead print a safe summary. Since we cannot change `get_provider_config()` itself (it is used elsewhere) and we should not alter its return structure, we will just adjust the test script’s logging. Specifically, in `ai_service/test_providers.py`, we will replace `print(f"Configuration: {config}\n")` with logic that builds a derived dictionary that excludes known secret keys (`api_key`) and, if desired, replaces them with placeholders like `"<redacted>"`. This still gives the tester useful information about which provider and model are being used, while preventing secrets from appearing in cleartext. No new imports are required; we can operate directly on the dictionary.

Concretely:
- In `test_provider` in `ai_service/test_providers.py`, replace the `print(f"Configuration: {config}\n")` line with something like:
  - Compute `safe_config = {k: ('<redacted>' if k == 'api_key' and v is not None else v) for k, v in config.items()}`.
  - Then print `safe_config` instead: `print(f"Configuration: {safe_config}\n")`.
This ensures any API key entries are masked, handling both HuggingFace and vcap configs, while keeping all other fields intact.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
