### PR TITLE
Potential fix for code scanning alert no. 11: Information exposure through an exception

### DIFF
--- a/ai_service/app/api/endpoints.py
+++ b/ai_service/app/api/endpoints.py
@@ -2613,7 +2613,7 @@ Please provide your analysis in JSON format:
 
     except json.JSONDecodeError as e:
         logger.error(f"Failed to parse AI response as JSON: {str(e)}")
-        # Return a fallback response
+        # Return a fallback response without exposing internal error details
         return {
             "report_id": str(uuid.uuid4()),
             "risk_level": "UNKNOWN",
@@ -2626,7 +2626,7 @@ Please provide your analysis in JSON format:
             "immediate_actions": ["Review findings manually"],
             "short_term_actions": [],
             "long_term_actions": [],
-            "error": str(e),
+            "error": "FALLBACK_PARSING_ERROR",
         }
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/sharma-manish-94/schemasculpt/security/code-scanning/11](https://github.com/sharma-manish-94/schemasculpt/security/code-scanning/11)

In general, to fix information exposure through exceptions you should avoid returning raw exception messages or stack traces to clients. Instead, log detailed errors on the server (with stack traces) and return a generic, non-sensitive message and perhaps a stable error code.

Specifically here, the problematic flow originates in `_analyze_attack_chains_with_ai`, where the `json.JSONDecodeError` handler builds a fallback `report` dictionary that includes `"error": str(e)`. That dictionary is used as the `report` value that eventually gets returned by the findings-based attack path endpoint. To maintain functionality while eliminating sensitive exposure, we should remove the direct inclusion of `str(e)` in the response and replace it with a generic message (e.g., `"Failed to parse AI analysis"`). Detailed exception information is already logged (`logger.error(f"Failed to parse AI response as JSON: {str(e)}")`), so we do not need to add more logging.

Concretely:
- In `ai_service/app/api/endpoints.py`, inside the `except json.JSONDecodeError as e:` block near lines 2614–2629, change the `"error"` value from `str(e)` to a generic, non-sensitive string.
- Do not change the structure or keys of the returned dictionary, so existing consumers are unaffected.
- No additional imports or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
